### PR TITLE
Fix license identifier in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,5 @@
   "scripts": {
   },
   "author": "Anupam Jain",
-  "license": "Apache2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
This PR fixes the license identifier listed in the `package.json` to be a valid SPDX identifier.

### Motivation

`supply` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have this license issue addressed in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.